### PR TITLE
revert: remove @typescript-eslint/strict-boolean-expressions

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,21 +74,6 @@ const eslintConfig = {
     {
       files: ['**/*.{ts,vue}'],
       extends: ['plugin:@typescript-eslint/recommended-requiring-type-checking'],
-      rules: {
-        '@typescript-eslint/strict-boolean-expressions': [
-          'error',
-          {
-            allowString: false,
-            allowNumber: false,
-            allowNullableObject: false,
-            allowNullableBoolean: false,
-            allowNullableString: false,
-            allowNullableNumber: false,
-            allowAny: false,
-            allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: false,
-          },
-        ],
-      },
     },
   ],
   reportUnusedDisableDirectives: true,


### PR DESCRIPTION
introducing this was a breaking change
to properly introduce this it needs to be configured less strict
reverts #5