### PR TITLE
feat: upgrade @typescript-eslint/*

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@intlify/eslint-plugin-vue-i18n": "0.11.1",
     "@rushstack/eslint-patch": "1.0.6",
-    "@typescript-eslint/eslint-plugin": "4.28.1",
-    "@typescript-eslint/parser": "4.28.1",
+    "@typescript-eslint/eslint-plugin": "5.6.0",
+    "@typescript-eslint/parser": "5.6.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.23.4",
     "eslint-plugin-jest": "24.3.6",
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@geprog/semantic-release-config": "1.0.0",
-    "@typescript-eslint/experimental-utils": "4.28.1",
+    "@typescript-eslint/experimental-utils": "5.6.0",
     "prettier": "2.3.2",
     "semantic-release": "18.0.0",
     "typescript": "4.3.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,9 @@ specifiers:
   '@geprog/semantic-release-config': 1.0.0
   '@intlify/eslint-plugin-vue-i18n': 0.11.1
   '@rushstack/eslint-patch': 1.0.6
-  '@typescript-eslint/eslint-plugin': 4.28.1
-  '@typescript-eslint/experimental-utils': 4.28.1
-  '@typescript-eslint/parser': 4.28.1
+  '@typescript-eslint/eslint-plugin': 5.6.0
+  '@typescript-eslint/experimental-utils': 5.6.0
+  '@typescript-eslint/parser': 5.6.0
   eslint-config-prettier: 8.3.0
   eslint-plugin-import: 2.23.4
   eslint-plugin-jest: 24.3.6
@@ -23,11 +23,11 @@ specifiers:
 dependencies:
   '@intlify/eslint-plugin-vue-i18n': 0.11.1
   '@rushstack/eslint-patch': 1.0.6
-  '@typescript-eslint/eslint-plugin': 4.28.1_dd9e8ceaccaad13387e03adf5b254629
-  '@typescript-eslint/parser': 4.28.1_typescript@4.3.5
+  '@typescript-eslint/eslint-plugin': 5.6.0_9ee87e45095b1e723363993494838175
+  '@typescript-eslint/parser': 5.6.0_typescript@4.3.5
   eslint-config-prettier: 8.3.0
   eslint-plugin-import: 2.23.4
-  eslint-plugin-jest: 24.3.6_9f7f9adfd48dcf5bc5ded5084e3ae85a
+  eslint-plugin-jest: 24.3.6_e4e0958c1b037ac99997652404e058f1
   eslint-plugin-prettier: 3.4.0_ae3805332b62cec006ed24a9ec35ea79
   eslint-plugin-promise: 5.1.0
   eslint-plugin-simple-import-sort: 7.0.0
@@ -37,7 +37,7 @@ dependencies:
 
 devDependencies:
   '@geprog/semantic-release-config': 1.0.0_semantic-release@18.0.0
-  '@typescript-eslint/experimental-utils': 4.28.1_typescript@4.3.5
+  '@typescript-eslint/experimental-utils': 5.6.0_typescript@4.3.5
   prettier: 2.3.2
   semantic-release: 18.0.0
   typescript: 4.3.5
@@ -252,7 +252,7 @@ packages:
       conventional-changelog-angular: 5.0.12
       conventional-commits-filter: 2.0.7
       conventional-commits-parser: 3.2.1
-      debug: 4.3.1
+      debug: 4.3.3
       import-from: 4.0.0
       lodash: 4.17.21
       micromatch: 4.0.4
@@ -280,7 +280,7 @@ packages:
       '@semantic-release/error': 2.2.0
       aggregate-error: 3.1.0
       bottleneck: 2.19.5
-      debug: 4.3.1
+      debug: 4.3.3
       dir-glob: 3.0.1
       fs-extra: 10.0.0
       globby: 11.0.4
@@ -329,7 +329,7 @@ packages:
       conventional-changelog-writer: 5.0.0
       conventional-commits-filter: 2.0.7
       conventional-commits-parser: 3.2.1
-      debug: 4.3.1
+      debug: 4.3.3
       get-stream: 6.0.1
       import-from: 4.0.0
       into-stream: 6.0.0
@@ -345,8 +345,8 @@ packages:
     engines: {node: '>= 10'}
     dev: true
 
-  /@types/json-schema/7.0.7:
-    resolution: {integrity: sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==}
+  /@types/json-schema/7.0.9:
+    resolution: {integrity: sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==}
 
   /@types/json5/0.0.29:
     resolution: {integrity: sha1-7ihweulOEdK4J7y+UnC86n8+ce4=}
@@ -368,22 +368,23 @@ packages:
     resolution: {integrity: sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin/4.28.1_dd9e8ceaccaad13387e03adf5b254629:
-    resolution: {integrity: sha512-9yfcNpDaNGQ6/LQOX/KhUFTR1sCKH+PBr234k6hI9XJ0VP5UqGxap0AnNwBnWFk1MNyWBylJH9ZkzBXC+5akZQ==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /@typescript-eslint/eslint-plugin/5.6.0_9ee87e45095b1e723363993494838175:
+    resolution: {integrity: sha512-MIbeMy5qfLqtgs1hWd088k1hOuRsN9JrHUPwVVKCD99EOUqScd7SrwoZl4Gso05EAP9w1kvLWUVGJOVpRPkDPA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^4.0.0
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.28.1_typescript@4.3.5
-      '@typescript-eslint/parser': 4.28.1_typescript@4.3.5
-      '@typescript-eslint/scope-manager': 4.28.1
-      debug: 4.3.1
+      '@typescript-eslint/experimental-utils': 5.6.0_typescript@4.3.5
+      '@typescript-eslint/parser': 5.6.0_typescript@4.3.5
+      '@typescript-eslint/scope-manager': 5.6.0
+      debug: 4.3.3
       functional-red-black-tree: 1.0.1
+      ignore: 5.1.8
       regexpp: 3.2.0
       semver: 7.3.5
       tsutils: 3.21.0_typescript@4.3.5
@@ -398,7 +399,7 @@ packages:
     peerDependencies:
       eslint: '*'
     dependencies:
-      '@types/json-schema': 7.0.7
+      '@types/json-schema': 7.0.9
       '@typescript-eslint/scope-manager': 4.28.1
       '@typescript-eslint/types': 4.28.1
       '@typescript-eslint/typescript-estree': 4.28.1_typescript@4.3.5
@@ -407,21 +408,38 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+    dev: false
 
-  /@typescript-eslint/parser/4.28.1_typescript@4.3.5:
-    resolution: {integrity: sha512-UjrMsgnhQIIK82hXGaD+MCN8IfORS1CbMdu7VlZbYa8LCZtbZjJA26De4IPQB7XYZbL8gJ99KWNj0l6WD0guJg==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /@typescript-eslint/experimental-utils/5.6.0_typescript@4.3.5:
+    resolution: {integrity: sha512-VDoRf3Qj7+W3sS/ZBXZh3LBzp0snDLEgvp6qj0vOAIiAPM07bd5ojQ3CTzF/QFl5AKh7Bh1ycgj6lFBJHUt/DA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
+      eslint: '*'
+    dependencies:
+      '@types/json-schema': 7.0.9
+      '@typescript-eslint/scope-manager': 5.6.0
+      '@typescript-eslint/types': 5.6.0
+      '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.3.5
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  /@typescript-eslint/parser/5.6.0_typescript@4.3.5:
+    resolution: {integrity: sha512-YVK49NgdUPQ8SpCZaOpiq1kLkYRPMv9U5gcMrywzI8brtwZjr/tG3sZpuHyODt76W/A0SufNjYt9ZOgrC4tLIQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 4.28.1
-      '@typescript-eslint/types': 4.28.1
-      '@typescript-eslint/typescript-estree': 4.28.1_typescript@4.3.5
-      debug: 4.3.1
+      '@typescript-eslint/scope-manager': 5.6.0
+      '@typescript-eslint/types': 5.6.0
+      '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.3.5
+      debug: 4.3.3
       typescript: 4.3.5
     transitivePeerDependencies:
       - supports-color
@@ -433,10 +451,23 @@ packages:
     dependencies:
       '@typescript-eslint/types': 4.28.1
       '@typescript-eslint/visitor-keys': 4.28.1
+    dev: false
+
+  /@typescript-eslint/scope-manager/5.6.0:
+    resolution: {integrity: sha512-1U1G77Hw2jsGWVsO2w6eVCbOg0HZ5WxL/cozVSTfqnL/eB9muhb8THsP0G3w+BB5xAHv9KptwdfYFAUfzcIh4A==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.6.0
+      '@typescript-eslint/visitor-keys': 5.6.0
 
   /@typescript-eslint/types/4.28.1:
     resolution: {integrity: sha512-4z+knEihcyX7blAGi7O3Fm3O6YRCP+r56NJFMNGsmtdw+NCdpG5SgNz427LS9nQkRVTswZLhz484hakQwB8RRg==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
+    dev: false
+
+  /@typescript-eslint/types/5.6.0:
+    resolution: {integrity: sha512-OIZffked7mXv4mXzWU5MgAEbCf9ecNJBKi+Si6/I9PpTaj+cf2x58h2oHW5/P/yTnPkKaayfjhLvx+crnl5ubA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   /@typescript-eslint/typescript-estree/4.28.1_typescript@4.3.5:
     resolution: {integrity: sha512-GhKxmC4sHXxHGJv8e8egAZeTZ6HI4mLU6S7FUzvFOtsk7ZIDN1ksA9r9DyOgNqowA9yAtZXV0Uiap61bIO81FQ==}
@@ -449,9 +480,30 @@ packages:
     dependencies:
       '@typescript-eslint/types': 4.28.1
       '@typescript-eslint/visitor-keys': 4.28.1
-      debug: 4.3.1
+      debug: 4.3.3
       globby: 11.0.4
       is-glob: 4.0.1
+      semver: 7.3.5
+      tsutils: 3.21.0_typescript@4.3.5
+      typescript: 4.3.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@typescript-eslint/typescript-estree/5.6.0_typescript@4.3.5:
+    resolution: {integrity: sha512-92vK5tQaE81rK7fOmuWMrSQtK1IMonESR+RJR2Tlc7w4o0MeEdjgidY/uO2Gobh7z4Q1hhS94Cr7r021fMVEeA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.6.0
+      '@typescript-eslint/visitor-keys': 5.6.0
+      debug: 4.3.3
+      globby: 11.0.4
+      is-glob: 4.0.3
       semver: 7.3.5
       tsutils: 3.21.0_typescript@4.3.5
       typescript: 4.3.5
@@ -464,6 +516,14 @@ packages:
     dependencies:
       '@typescript-eslint/types': 4.28.1
       eslint-visitor-keys: 2.1.0
+    dev: false
+
+  /@typescript-eslint/visitor-keys/5.6.0:
+    resolution: {integrity: sha512-1p7hDp5cpRFUyE3+lvA74egs+RWSgumrBpzBCDzfTFv0aQ7lIeay80yU0hIxgAhwQ6PcasW35kaOCyDOv6O/Ng==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.6.0
+      eslint-visitor-keys: 3.1.0
 
   /JSONStream/1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -491,7 +551,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.1
+      debug: 4.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -844,6 +904,17 @@ packages:
     dependencies:
       ms: 2.1.2
 
+  /debug/4.3.3:
+    resolution: {integrity: sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+
   /decamelize-keys/1.1.0:
     resolution: {integrity: sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=}
     engines: {node: '>=0.10.0'}
@@ -1027,7 +1098,7 @@ packages:
       tsconfig-paths: 3.9.0
     dev: false
 
-  /eslint-plugin-jest/24.3.6_9f7f9adfd48dcf5bc5ded5084e3ae85a:
+  /eslint-plugin-jest/24.3.6_e4e0958c1b037ac99997652404e058f1:
     resolution: {integrity: sha512-WOVH4TIaBLIeCX576rLcOgjNXqP+jNlCiEmRgFTfQtJ52DpwnIQKAVGlGPAN7CZ33bW6eNfHD6s8ZbEUTQubJg==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -1037,7 +1108,7 @@ packages:
       '@typescript-eslint/eslint-plugin':
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.28.1_dd9e8ceaccaad13387e03adf5b254629
+      '@typescript-eslint/eslint-plugin': 5.6.0_9ee87e45095b1e723363993494838175
       '@typescript-eslint/experimental-utils': 4.28.1_typescript@4.3.5
     transitivePeerDependencies:
       - supports-color
@@ -1136,6 +1207,10 @@ packages:
   /eslint-visitor-keys/2.1.0:
     resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
     engines: {node: '>=10'}
+
+  /eslint-visitor-keys/3.1.0:
+    resolution: {integrity: sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   /espree/6.2.1:
     resolution: {integrity: sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==}
@@ -1343,7 +1418,7 @@ packages:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
     dependencies:
-      is-glob: 4.0.1
+      is-glob: 4.0.3
 
   /glob/7.1.7:
     resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
@@ -1433,7 +1508,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.1
+      debug: 4.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1443,7 +1518,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.1
+      debug: 4.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1541,6 +1616,12 @@ packages:
 
   /is-glob/4.0.1:
     resolution: {integrity: sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-extglob: 2.1.1
+
+  /is-glob/4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
@@ -2255,7 +2336,7 @@ packages:
     resolution: {integrity: sha512-W6LFRRkVPT4qEQsF320wXbV1uss8YJT5Y+wX6LZKziVFXkQ1rUK+hRl6Q9O4sgq7MwWQMq0VFcuPTLri9RHFqg==}
     engines: {node: ^8.10.0 || ^10.13.0 || ^11.10.1 || >=12.13.0}
     dependencies:
-      debug: 4.3.1
+      debug: 4.3.3
       fast-diff: 1.2.0
       lodash.sortedlastindex: 4.1.0
       postcss: 8.3.5
@@ -2847,6 +2928,7 @@ packages:
     resolution: {integrity: sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==}
     engines: {node: '>=0.8.0'}
     hasBin: true
+    requiresBuild: true
     dev: true
     optional: true
 


### PR DESCRIPTION
adds support for typescript 4.5

BREAKING CHANGE: see https://github.com/typescript-eslint/typescript-eslint/releases/tag/v5.0.0