### PR TITLE
chore: update eslint-plugin-vue-scoped-css

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eslint-plugin-promise": "5.1.0",
     "eslint-plugin-simple-import-sort": "7.0.0",
     "eslint-plugin-vue": "7.12.1",
-    "eslint-plugin-vue-scoped-css": "1.2.1",
+    "eslint-plugin-vue-scoped-css": "1.3.0",
     "vue-eslint-parser": "7.6.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ specifiers:
   eslint-plugin-promise: 5.1.0
   eslint-plugin-simple-import-sort: 7.0.0
   eslint-plugin-vue: 7.12.1
-  eslint-plugin-vue-scoped-css: 1.2.1
+  eslint-plugin-vue-scoped-css: 1.3.0
   prettier: 2.3.2
   semantic-release: 18.0.0
   typescript: 4.3.5
@@ -32,7 +32,7 @@ dependencies:
   eslint-plugin-promise: 5.1.0
   eslint-plugin-simple-import-sort: 7.0.0
   eslint-plugin-vue: 7.12.1
-  eslint-plugin-vue-scoped-css: 1.2.1_vue-eslint-parser@7.6.0
+  eslint-plugin-vue-scoped-css: 1.3.0_vue-eslint-parser@7.6.0
   vue-eslint-parser: 7.6.0
 
 devDependencies:
@@ -1073,17 +1073,17 @@ packages:
       eslint: '>=5.0.0'
     dev: false
 
-  /eslint-plugin-vue-scoped-css/1.2.1_vue-eslint-parser@7.6.0:
-    resolution: {integrity: sha512-YUZy4fG5oRh2jVqULt8v6pDg9PSj10d5IaDMTplW3jgqli7tZkFg951j4GjOX/BxVBElLJHbgYTsy2TWoJ/ENA==}
+  /eslint-plugin-vue-scoped-css/1.3.0_vue-eslint-parser@7.6.0:
+    resolution: {integrity: sha512-jVFnjV7yZvPZeNVyqkSTM8OF0fV21gYdejK9+DigoxxdSSh48HjLsELdLnMvvr637wxovpeGrZely5hek57GMw==}
     engines: {node: ^8.10.0 || ^10.13.0 || ^12.13.0 || ^13.0.0 || >=14.0.0}
     peerDependencies:
-      eslint: 7.27.0
-      vue-eslint-parser: ^7.1.0
+      eslint: '>=6.0.0'
+      vue-eslint-parser: '>=7.1.0'
     dependencies:
       eslint-utils: 3.0.0
       lodash: 4.17.21
       postcss: 8.3.5
-      postcss-safe-parser: 5.0.2
+      postcss-safe-parser: 6.0.0_postcss@8.3.5
       postcss-scss: 3.0.5
       postcss-selector-parser: 6.0.6
       postcss-styl: 0.8.0
@@ -2229,9 +2229,11 @@ packages:
       find-up: 2.1.0
     dev: false
 
-  /postcss-safe-parser/5.0.2:
-    resolution: {integrity: sha512-jDUfCPJbKOABhwpUKcqCVbbXiloe/QXMcbJ6Iipf3sDIihEzTqRCeMBfRaOHxhBuTYqtASrI1KJWxzztZU4qUQ==}
-    engines: {node: '>=10.0'}
+  /postcss-safe-parser/6.0.0_postcss@8.3.5:
+    resolution: {integrity: sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.3.3
     dependencies:
       postcss: 8.3.5
     dev: false
@@ -2847,6 +2849,7 @@ packages:
     resolution: {integrity: sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==}
     engines: {node: '>=0.8.0'}
     hasBin: true
+    requiresBuild: true
     dev: true
     optional: true
 


### PR DESCRIPTION
includes a peer dependency fix and eslint 8 support