### PR TITLE
fix: disable jest/prefer-snapshot-hint

### DIFF
--- a/jest.js
+++ b/jest.js
@@ -19,6 +19,7 @@ const eslintConfig = {
         'jest/prefer-expect-assertions': ['error', { onlyFunctionsWithAsyncKeyword: true }],
         'jest/prefer-lowercase-title': ['error', { ignore: ['describe'] }],
         'jest/no-hooks': 'off',
+        'jest/prefer-snapshot-hint': 'off',
       },
     },
   ],


### PR DESCRIPTION
This reverts a breaking change introduced in version [1.0.4](https://github.com/geprog/eslint-config/releases/tag/v1.0.4)

The rule ([jest/prefer-snapshot-hint](https://github.com/jest-community/eslint-plugin-jest/blob/v26.1.1/docs/rules/prefer-snapshot-hint.md)) might be nice eventually but annoying to fix right now.